### PR TITLE
Add textarea contents as text, not HTML

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -89,7 +89,7 @@ function displayMessages(msg){
   }
   linesAfterMessages.reverse()
   receivedMsg.reverse()
-  $('#myTextarea').html(textArea).text()
+  $('#myTextarea').val(textArea)
   if (first_request){
     first_request = false
     restoreTextareaScroll('#myTextarea')


### PR DESCRIPTION
Currently, if the logs happen to contain anything that resembles an HTML tag, it'll get cut off; this prevents that.