### PR TITLE
Add support for action "messageActionChatAddUsers"

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -190,6 +190,7 @@ function processGetHistoryResponse(peerID,res,AppMesMng,AppUsrMng,AppChatsMng,Ap
 						msgServiceText = 'upgraded the group to a supergroup'
 						break
 					case 'messageActionChatAddUser': //invited {users.name....}
+					case 'messageActionChatAddUsers':
 						msgServiceText = 'invited '
 						for(var iuser=0; iuser<msgWrap.action.users.length; iuser++){
 							var invited_uid = msgWrap.action.users[iuser]


### PR DESCRIPTION
If multiple users were invited to the chat, there is action `messageActionChatAddUsers` is fired instead of `messageActionChatAddUser`. This PR adds support for this action, so instead of error "unsupported service message type" for this action it properly displays invitation information.